### PR TITLE
perf: reduce allocation pressure by changing usage of Iterator::fold to concat

### DIFF
--- a/src/concat_source.rs
+++ b/src/concat_source.rs
@@ -78,26 +78,22 @@ impl ConcatSource {
 
 impl Source for ConcatSource {
   fn source(&self) -> Cow<str> {
-    let all = self.children.iter().fold(String::new(), |mut acc, cur| {
-      acc.push_str(&cur.source());
-      acc
-    });
+    let all = self.children.iter().map(|child| child.source()).collect();
     Cow::Owned(all)
   }
 
   fn buffer(&self) -> Cow<[u8]> {
-    let all = self.children.iter().fold(Vec::new(), |mut acc, cur| {
-      acc.extend(&*cur.buffer());
-      acc
-    });
+    let all = self
+      .children
+      .iter()
+      .map(|child| child.buffer())
+      .collect::<Vec<_>>()
+      .concat();
     Cow::Owned(all)
   }
 
   fn size(&self) -> usize {
-    self.children.iter().fold(0, |mut acc, cur| {
-      acc += cur.size();
-      acc
-    })
+    self.children.iter().map(|child| child.size()).sum()
   }
 
   fn map(&self, options: &MapOptions) -> Option<SourceMap> {


### PR DESCRIPTION
`fold` allocates capacity multiple times, meanwhile `concat` allocates capacity all at once.

https://github.com/rust-lang/rust/blob/1146560e1a53d26d04b33548d4eeb8e083d78509/library/alloc/src/slice.rs#L705-L712

found via dhat

<img width="1684" alt="image" src="https://user-images.githubusercontent.com/1430279/211030548-35a2f97d-55e2-4ff0-b18c-d79d587b8949.png">
